### PR TITLE
update dbt_project.yml to include '6' in the vars "payment_type_values"

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,4 +40,4 @@ models:
     +materialized: table
 
 vars:
-  payment_type_values: [1, 2, 3, 4, 5]
+  payment_type_values: [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
I ran the project in development environment and it raised an error at `stg_greet_taxi` since it found a value outside of predifined values for "payment_type_values" variable.