### PR TITLE
corrected miss spelling at schema.yml in "'test.taxi_rides_ny.relatio…

### DIFF
--- a/models/core/schema.yml
+++ b/models/core/schema.yml
@@ -14,7 +14,7 @@ models:
     columns:
       - name: revenue_monthly_total_amount
         description: Monthly sum of the the total_amount of the fare charged for the trip per pickup zone, month and service.
-        tests:
+        data_tests:
             - not_null:
                 severity: error
       

--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -18,7 +18,7 @@ models:
       - name: tripid
         data_type: string
         description: ""
-        tests:
+        data_tests:
           - unique:
               severity: warn
           - not_null:
@@ -35,16 +35,16 @@ models:
       - name: pickup_locationid
         data_type: int64
         description: ""
-        tests:
+        data_tests:
           - relationships:
-              to: ref('taxi_zone_lookup')
               field: locationid
+              to: ref('taxi_zone_lookup')
               severity: warn
 
       - name: dropoff_locationid
         data_type: int64
         description: ""
-        tests:
+        data_tests:
           - relationships:
               field: locationid
               to: "ref('taxi_zone_lookup')"
@@ -109,7 +109,7 @@ models:
       - name: payment_type
         data_type: int64
         description: ""
-        tests:
+        data_tests:
           - accepted_values:
               values: "{{ var('payment_type_values') }}"
               severity: warn
@@ -125,7 +125,7 @@ models:
       - name: tripid
         data_type: string
         description: ""
-        tests:
+        data_tests:
           - unique:
               severity: warn
           - not_null:
@@ -142,19 +142,19 @@ models:
       - name: pickup_locationid
         data_type: int64
         description: ""
-        tests:
+        data_tests:
           - relationships:
               field: locationid
-              to: ref('taxi_zone-lookup')
+              to: ref('taxi_zone_lookup')
               severity: warn
 
       - name: dropoff_locationid
         data_type: int64
         description: ""
-        tests:
+        data_tests:
           - relationships:
               field: locationid
-              to: ref('taxi_zone-lookup')
+              to: ref('taxi_zone_lookup')
               severity: warn
 
       - name: pickup_datetime
@@ -216,7 +216,7 @@ models:
       - name: payment_type
         data_type: int64
         description: ""
-        tests:
+        data_tests:
           - accepted_values:
               values: "{{ var('payment_type_values') }}"
               severity: warn


### PR DESCRIPTION
…nships_stg_yellow_trips_pickup_locationid" from 'taxi_zone-lookup' to 'taxi_zone_lookup' (with underscore)... and changed 'tests' config to 'data_tests' which was raising a Deprecated functionality